### PR TITLE
Improve version constraint for github provider

### DIFF
--- a/modules/org-organization/README.md
+++ b/modules/org-organization/README.md
@@ -11,7 +11,7 @@ This module creates following resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | = 4.13.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.13.0 |
 
 ## Providers
 
@@ -27,10 +27,10 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [github_membership.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/resources/membership) | resource |
-| [github_organization_block.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/resources/organization_block) | resource |
-| [github_organization.after](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/data-sources/organization) | data source |
-| [github_organization.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/data-sources/organization) | data source |
+| [github_membership.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/membership) | resource |
+| [github_organization_block.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/organization_block) | resource |
+| [github_organization.after](https://registry.terraform.io/providers/hashicorp/github/latest/docs/data-sources/organization) | data source |
+| [github_organization.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/data-sources/organization) | data source |
 
 ## Inputs
 

--- a/modules/org-organization/versions.tf
+++ b/modules/org-organization/versions.tf
@@ -3,10 +3,8 @@ terraform {
 
   required_providers {
     github = {
-      # source  = "integrations/github"
-      # version = ">= 4.19"
       source  = "hashicorp/github"
-      version = "= 4.13.0"
+      version = ">= 4.13.0"
     }
   }
 }

--- a/modules/org-team/README.md
+++ b/modules/org-team/README.md
@@ -11,7 +11,7 @@ This module creates following resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | = 4.13.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.13.0 |
 
 ## Providers
 
@@ -27,8 +27,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [github_team.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/resources/team) | resource |
-| [github_team_membership.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/resources/team_membership) | resource |
+| [github_team.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/team) | resource |
+| [github_team_membership.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/team_membership) | resource |
 
 ## Inputs
 

--- a/modules/org-team/versions.tf
+++ b/modules/org-team/versions.tf
@@ -3,10 +3,8 @@ terraform {
 
   required_providers {
     github = {
-      # source  = "integrations/github"
-      # version = ">= 4.19"
       source  = "hashicorp/github"
-      version = "= 4.13.0"
+      version = ">= 4.13.0"
     }
   }
 }

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -12,7 +12,7 @@ This module creates following resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | = 4.13.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.13.0 |
 
 ## Providers
 
@@ -28,9 +28,9 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [github_organization_project.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/resources/organization_project) | resource |
-| [github_project_column.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/resources/project_column) | resource |
-| [github_repository_project.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/resources/repository_project) | resource |
+| [github_organization_project.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/organization_project) | resource |
+| [github_project_column.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/project_column) | resource |
+| [github_repository_project.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/repository_project) | resource |
 
 ## Inputs
 

--- a/modules/project/versions.tf
+++ b/modules/project/versions.tf
@@ -3,10 +3,8 @@ terraform {
 
   required_providers {
     github = {
-      # source  = "integrations/github"
-      # version = ">= 4.19"
       source  = "hashicorp/github"
-      version = "= 4.13.0"
+      version = ">= 4.13.0"
     }
   }
 }

--- a/modules/repository/README.md
+++ b/modules/repository/README.md
@@ -15,7 +15,7 @@ This module creates following resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | = 4.13.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.13.0 |
 
 ## Providers
 
@@ -31,12 +31,12 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [github_branch_default.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/resources/branch_default) | resource |
-| [github_issue_label.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/resources/issue_label) | resource |
-| [github_repository.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/resources/repository) | resource |
-| [github_repository_collaborator.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/resources/repository_collaborator) | resource |
-| [github_repository_deploy_key.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/resources/repository_deploy_key) | resource |
-| [github_team_repository.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/resources/team_repository) | resource |
+| [github_branch_default.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/branch_default) | resource |
+| [github_issue_label.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/issue_label) | resource |
+| [github_repository.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/repository) | resource |
+| [github_repository_collaborator.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/repository_collaborator) | resource |
+| [github_repository_deploy_key.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/repository_deploy_key) | resource |
+| [github_team_repository.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/team_repository) | resource |
 
 ## Inputs
 

--- a/modules/repository/versions.tf
+++ b/modules/repository/versions.tf
@@ -3,10 +3,8 @@ terraform {
 
   required_providers {
     github = {
-      # source  = "integrations/github"
-      # version = ">= 4.19"
       source  = "hashicorp/github"
-      version = "= 4.13.0"
+      version = ">= 4.13.0"
     }
   }
 }

--- a/modules/webhook/README.md
+++ b/modules/webhook/README.md
@@ -11,7 +11,7 @@ This module creates following resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | = 4.13.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.13.0 |
 
 ## Providers
 
@@ -27,8 +27,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [github_organization_webhook.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/resources/organization_webhook) | resource |
-| [github_repository_webhook.this](https://registry.terraform.io/providers/hashicorp/github/4.13.0/docs/resources/repository_webhook) | resource |
+| [github_organization_webhook.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/organization_webhook) | resource |
+| [github_repository_webhook.this](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/repository_webhook) | resource |
 
 ## Inputs
 

--- a/modules/webhook/versions.tf
+++ b/modules/webhook/versions.tf
@@ -3,10 +3,8 @@ terraform {
 
   required_providers {
     github = {
-      # source  = "integrations/github"
-      # version = ">= 4.19"
       source  = "hashicorp/github"
-      version = "= 4.13.0"
+      version = ">= 4.13.0"
     }
   }
 }


### PR DESCRIPTION
### Background

- Change version constraint for `github` provider from `= 4.13.0` to `>= 4.13.0`