### PR TITLE
fix(repository-environment): replace deprecated `plaintext_value` with `value`

### DIFF
--- a/modules/repository-environment/main.tf
+++ b/modules/repository-environment/main.tf
@@ -98,12 +98,12 @@ resource "github_actions_environment_secret" "this" {
   repository  = var.repository
   environment = github_repository_environment.this.environment
 
-  secret_name     = each.key
-  plaintext_value = "placeholder"
+  secret_name = each.key
+  value       = "placeholder"
   # key_id          = var.key_id
-  # encrypted_value = each.value
+  # value_encrypted = each.value
 
   lifecycle {
-    ignore_changes = [plaintext_value]
+    ignore_changes = [value]
   }
 }

--- a/modules/repository-environment/main.tf
+++ b/modules/repository-environment/main.tf
@@ -92,6 +92,9 @@ resource "github_actions_environment_variable" "this" {
 # Secrets for Repository Environment
 ###################################################
 
+# INFO: Deprecated attributes
+# - `plaintext_value`
+# - `encrypted_value`
 resource "github_actions_environment_secret" "this" {
   for_each = var.secrets
 


### PR DESCRIPTION
## Summary

The `integrations/github` provider deprecated the `plaintext_value` argument on the `github_actions_environment_secret` resource in favor of `value`. This produced a deprecation warning for every environment secret managed through this module:

```
Warning: Argument is deprecated
  with ...github_actions_environment_secret.this,
  on .../repository-environment/main.tf line 102 ...
  102:   plaintext_value = "placeholder"
Use value.
```

## Changes

- `plaintext_value = "placeholder"` → `value = "placeholder"`
- `lifecycle.ignore_changes = [plaintext_value]` → `[value]`
- Updated the commented-out hint `encrypted_value` → its replacement `value_encrypted` for consistency

## Notes

- Behavior is unchanged — `value` is the direct, provider-recommended replacement for `plaintext_value`. The placeholder-secret pattern (`ignore_changes`) is preserved.
- `terraform validate` passes.